### PR TITLE
Fix TS declaration for Promise of new "react" method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -704,7 +704,7 @@ declare namespace WAWebJS {
          */
         reply: (content: MessageContent, chatId?: string, options?: MessageSendOptions) => Promise<Message>,
         /** React to this message with an emoji*/
-        react: (reaction: string) => Promise,
+        react: (reaction: string) => Promise<void>,
         /** 
          * Forwards this message to another chat
          */


### PR DESCRIPTION
Without explicit delaration of void <T> for Promise running tsc causing the error:

```
node_modules/whatsapp-web.js/index.d.ts:707:38 - error TS2314: Generic type 'Promise<T>' requires 1 type argument(s).
```